### PR TITLE
Add unit tests and remove unnecessary envs

### DIFF
--- a/.ci/docker/docker-compose.yml
+++ b/.ci/docker/docker-compose.yml
@@ -103,6 +103,4 @@ services:
     ports:
       - 80:80
     environment:
-      - PRIVATE_KEY
-      - PUBLIC_KEY
       - APP_ENV

--- a/.php_cs
+++ b/.php_cs
@@ -1,7 +1,7 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__.'/src/', __DIR__.'/tests/')
+    ->in([__DIR__.'/src/', __DIR__.'/tests/'])
     ->exclude(__DIR__.'/vendor/');
 
 $header = <<<EOF

--- a/src/Utility/StringUtility.php
+++ b/src/Utility/StringUtility.php
@@ -45,7 +45,7 @@ class StringUtility
         }
 
         return strtolower((string) preg_replace_callback('/([a-z])([A-Z])/', function ($matches) {
-            return $matches[1] ?? '' . '_' . strtolower((string) ($matches[2] ?? ''));
+            return ((string) $matches[1] ?? '') . '_' . strtolower((string) ($matches[2] ?? ''));
         }, $subject));
     }
 }

--- a/src/Utility/StringUtility.php
+++ b/src/Utility/StringUtility.php
@@ -40,13 +40,12 @@ class StringUtility
 
     public static function camelCaseToSnakeCase(string $subject): string
     {
-        $matches = [];
-        preg_match_all('!([A-Z][A-Z0-9]*(?=$|[A-Z][a-z0-9])|[A-Za-z][a-z0-9]+)!', $subject, $matches);
-        $result = $matches[0];
-        foreach ($result as &$match) {
-            $match = $match == strtoupper($match) ? strtolower($match) : lcfirst($match);
+        if (preg_match('/[A-Z]/', $subject) === 0) {
+            return $subject;
         }
 
-        return implode('_', $result);
+        return strtolower((string) preg_replace_callback('/([a-z])([A-Z])/', function ($matches) {
+            return $matches[1] ?? '' . '_' . strtolower((string) ($matches[2] ?? ''));
+        }, $subject));
     }
 }

--- a/tests/Api/JWTAuthTest.php
+++ b/tests/Api/JWTAuthTest.php
@@ -1,5 +1,29 @@
 <?php
 
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 Wolf Utz<wpu@hotmail.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 declare(strict_types=1);
 
 namespace OmegaCode\JwtSecuredApiCore\Tests\Api;
@@ -21,7 +45,7 @@ class JWTAuthTest extends TestCase
      */
     public function accessTokenRouteWithOutSecretReturns401(): void
     {
-        $response = $this->client->request('POST', 'http://api/auth', ['http_errors' => false,]);
+        $response = $this->client->request('POST', 'http://api/auth', ['http_errors' => false]);
         $this->assertEquals(401, $response->getStatusCode());
     }
 
@@ -32,7 +56,7 @@ class JWTAuthTest extends TestCase
     {
         $response = $this->client->request('POST', 'http://api/auth', [
             'http_errors' => false,
-            'json' => ["clientId" => "wrong-secret"]
+            'json' => ['clientId' => 'wrong-secret'],
         ]);
         $this->assertEquals(401, $response->getStatusCode());
     }
@@ -44,7 +68,7 @@ class JWTAuthTest extends TestCase
     {
         $response = $this->client->request('POST', 'http://api/auth', [
             'http_errors' => false,
-            'json' => ["clientId" => "1234"]// @see res/test/api/clients.test.json
+            'json' => ['clientId' => '1234'], // @see res/test/api/clients.test.json
         ]);
         $this->assertEquals(201, $response->getStatusCode());
     }
@@ -59,7 +83,7 @@ class JWTAuthTest extends TestCase
             'headers' => [
                 'Authorization' => 'Bearer wrong-token',
                 'Accept' => 'application/json',
-            ]
+            ],
         ]);
         $this->assertFalse(json_decode((string) $response->getBody(), true)['success']);
     }
@@ -71,7 +95,7 @@ class JWTAuthTest extends TestCase
     {
         $response = $this->client->request('POST', 'http://api/auth', [
             'http_errors' => false,
-            'json' => ["clientId" => "1234"]// @see res/test/api/clients.test.json
+            'json' => ['clientId' => '1234'], // @see res/test/api/clients.test.json
         ]);
         $result = json_decode((string) $response->getBody(), true);
         $this->assertArrayHasKey('access_token', $result);
@@ -81,7 +105,7 @@ class JWTAuthTest extends TestCase
             'headers' => [
                 'Authorization' => 'Bearer ' . $token,
                 'Accept' => 'application/json',
-            ]
+            ],
         ]);
         $this->assertTrue(json_decode((string) $response->getBody(), true)['success']);
     }

--- a/tests/Unit/Utility/ArrayUtilityTest.php
+++ b/tests/Unit/Utility/ArrayUtilityTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 Wolf Utz<wpu@hotmail.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace OmegaCode\JwtSecuredApiCore\Tests\Unit\Utility;
+
+use OmegaCode\JwtSecuredApiCore\Utility\ArrayUtility;
+use PHPUnit\Framework\TestCase;
+
+class ArrayUtilityTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function convertsSnakeCaseKeys(): void
+    {
+        $data = [
+            'my_test_string' => null,
+            'my_otherString' => null,
+        ];
+        $result = ArrayUtility::snakeCaseKeysToCamelCaseKeys($data);
+        $this->assertArrayHasKey('myTestString', $result);
+        $this->assertArrayHasKey('myOtherString', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresKebabCaseKeys(): void
+    {
+        $data = [
+            'my-kebab-string' => null,
+        ];
+        $result = ArrayUtility::snakeCaseKeysToCamelCaseKeys($data);
+        $this->assertArrayHasKey('my-kebab-string', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresCamelCaseKeys(): void
+    {
+        $data = [
+            'anOtherString' => null,
+        ];
+        $result = ArrayUtility::snakeCaseKeysToCamelCaseKeys($data);
+        $this->assertArrayHasKey('anOtherString', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function convertsPascalCaseKeys(): void
+    {
+        $data = [
+            'MyPascalCaseString' => null,
+        ];
+        $result = ArrayUtility::snakeCaseKeysToCamelCaseKeys($data);
+        $this->assertArrayHasKey('myPascalCaseString', $result);
+    }
+}

--- a/tests/Unit/Utility/StringUtilityTest.php
+++ b/tests/Unit/Utility/StringUtilityTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * MIT License
+ *
+ * Copyright (c) 2020 Wolf Utz<wpu@hotmail.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace OmegaCode\JwtSecuredApiCore\Tests\Unit\Utility;
+
+use OmegaCode\JwtSecuredApiCore\Utility\StringUtility;
+use PHPUnit\Framework\TestCase;
+
+class StringUtilityTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function convertsSnakeCaseToCamelCase(): void
+    {
+        $data = 'my_test_string';
+        $result = StringUtility::snakeCaseToCamelCase($data);
+        $this->assertEquals('myTestString', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresKebabCaseToCamelCase(): void
+    {
+        $data = 'my-test-string';
+        $result = StringUtility::snakeCaseToCamelCase($data);
+        $this->assertEquals($data, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresCamelCaseToCamelCase(): void
+    {
+        $data = 'myTestString';
+        $result = StringUtility::snakeCaseToCamelCase($data);
+        $this->assertEquals($data, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function convertsPascalCaseToCamelCase(): void
+    {
+        $data = 'MyTestString';
+        $result = StringUtility::snakeCaseToCamelCase($data);
+        $this->assertEquals('myTestString', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function convertsCamelCaseToSnakeCase(): void
+    {
+        $data = 'myTestString';
+        $result = StringUtility::camelCaseToSnakeCase($data);
+        $this->assertEquals('my_test_string', $result);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresKebabCaseToSnakeCase(): void
+    {
+        $data = 'my-test-string';
+        $result = StringUtility::camelCaseToSnakeCase($data);
+        $this->assertEquals($data, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function ignoresSnakeCaseToSnakeCase(): void
+    {
+        $data = 'my_test_string';
+        $result = StringUtility::camelCaseToSnakeCase($data);
+        $this->assertEquals($data, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function convertsPascalCaseToSnakeCase(): void
+    {
+        $data = 'MyTestString';
+        $result = StringUtility::camelCaseToSnakeCase($data);
+        $this->assertEquals('my_test_string', $result);
+    }
+}


### PR DESCRIPTION
Add ArrayUtility and StringUtility unit tests.
Fix StringUtility::camelCaseToSnakeCase.
Remove unnecessary envs in .ci/docker/docker-compose.yml.