### PR TITLE
Add loading of routes depending on environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,22 +58,22 @@
     },
     "scripts": {
         "unit": [
-            "./.ci/scripts/ciRunner.sh -s unit"
+            "./.ci/scripts/ciRunner.sh -s unit -p 7.4"
         ],
         "e2e": [
-            "./.ci/scripts/ciRunner.sh -s e2e"
+            "./.ci/scripts/ciRunner.sh -s e2e -p 7.4"
         ],
         "lint": [
-            "./.ci/scripts/ciRunner.sh -s lint"
+            "./.ci/scripts/ciRunner.sh -s lint -p 7.4"
         ],
         "fix": [
-            "./.ci/scripts/ciRunner.sh -s fix"
+            "./.ci/scripts/ciRunner.sh -s fix -p 7.4"
         ],
         "build": [
-            "./.ci/scripts/ciRunner.sh -s build"
+            "./.ci/scripts/ciRunner.sh -s build -p 7.4"
         ],
         "quality": [
-            "./.ci/scripts/ciRunner.sh -s quality"
+            "./.ci/scripts/ciRunner.sh -s quality -p 7.4"
         ]
     },
     "bin": [

--- a/conf/routes.test.yaml
+++ b/conf/routes.test.yaml
@@ -1,0 +1,11 @@
+routes:
+  -
+    name: auth.login
+    route: /auth
+    methods: [post,options]
+    action: OmegaCode\JwtSecuredApiCore\Action\Auth\LoginAction
+  -
+    name: auth.verify
+    route: /auth/verify
+    methods: [post,options]
+    action: OmegaCode\JwtSecuredApiCore\Action\Auth\VerifyAction

--- a/src/Core/Kernel/CliKernel.php
+++ b/src/Core/Kernel/CliKernel.php
@@ -41,7 +41,7 @@ class CliKernel extends AbstractKernel
             header('HTTP/1.1 500 Internal Server Error');
             header('Content-Type: application/json');
             echo 'Environment variable APP_ROOT_PATH is not set! CLI can not process.';
-            die();
+            exit();
         }
         parent::__construct();
     }

--- a/src/Core/Kernel/HttpKernel.php
+++ b/src/Core/Kernel/HttpKernel.php
@@ -56,7 +56,7 @@ class HttpKernel extends AbstractKernel
             header('Content-Type: application/json');
             echo (bool) $_ENV['SHOW_ERRORS'] ? '{"status": 500, "message": "Constant APP_ROOT_PATH is not defined"}' :
                 AbstractErrorHandler::DEFAULT_RESPONSE;
-            die();
+            exit();
         }
         (new LowLevelErrorHandler((bool) $_ENV['SHOW_ERRORS'], (bool) $_ENV['ENABLE_LOG']));
         parent::__construct();

--- a/src/Error/Handler/LowLevelErrorHandler.php
+++ b/src/Error/Handler/LowLevelErrorHandler.php
@@ -57,7 +57,7 @@ class LowLevelErrorHandler extends AbstractErrorHandler
             ob_end_clean();
         }
         echo $this->outputErrorInformation($type, $message, $file, $line);
-        die();
+        exit();
     }
 
     public function shutdown(): void

--- a/src/Provider/RouteCollectionProvider.php
+++ b/src/Provider/RouteCollectionProvider.php
@@ -71,7 +71,8 @@ class RouteCollectionProvider extends CachableDataProvider
 
     private function buildRouteCollection(): RouteCollection
     {
-        $configuration = $this->configurationFileService->load('routes.yaml');
+        $configurationFileName = $_ENV['APP_ENV'] === 'prod' ? 'routes.yaml' : 'routes.' . $_ENV['APP_ENV'] . '.yaml';
+        $configuration = $this->configurationFileService->load($configurationFileName);
 
         return CollectionFactory::build(
             (new RouteConfigurationProcessor())->process($configuration)

--- a/src/Route/Configuration.php
+++ b/src/Route/Configuration.php
@@ -99,7 +99,7 @@ class Configuration implements \Serializable
     public function isCacheable(): bool
     {
         foreach ($this->middlewares as $middleware) {
-            $interfaces = class_implements($middleware);
+            $interfaces = (array) class_implements($middleware);
             if (isset($interfaces[CacheableMiddlewareInterface::class])) {
                 return true;
             }


### PR DESCRIPTION
For example. If you define APP_ENV as "test"
the system checks for `routes.test.yaml` instead of `routes.yaml`.
This is extremely useful for e2e test.